### PR TITLE
Fix overwriting marked flag on BizHawk CDL import

### DIFF
--- a/Diz.Import/src/bizhawk/BizHawkCdlImporter.cs
+++ b/Diz.Import/src/bizhawk/BizHawkCdlImporter.cs
@@ -75,6 +75,9 @@ public class BizHawkCdlImporter
             if (cdlFlag == Flag.None)
                 continue;
 
+            if (snesData.GetFlag(offset) != FlagType.Unreached)
+                continue;
+
             var type = FlagType.Unreached;
             if ((cdlFlag & Flag.ExecFirst) != 0)
             {


### PR DESCRIPTION
The BizHawk CDL import option would previously overwrite a marked flag on the working project, such as resetting hand-marked text or graphics flags back to generic 8-bit data. This is in line with how the BSNES usage map importer works.