### PR TITLE
Add checkbox for "Output Extra Whitespace" setting in export settings

### DIFF
--- a/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
@@ -49,6 +49,7 @@ namespace DiztinGUIsh.window.dialog
             this.numData = new System.Windows.Forms.NumericUpDown();
             this.chkPrintLabelSpecificComments = new System.Windows.Forms.CheckBox();
             this.chkIncludeUnusedLabels = new System.Windows.Forms.CheckBox();
+            this.chkOutputExtraWhitespace = new System.Windows.Forms.CheckBox();
             this.saveLogSingleFile = new System.Windows.Forms.SaveFileDialog();
             this.chooseLogFolder = new System.Windows.Forms.FolderBrowserDialog();
             this.label7 = new System.Windows.Forms.Label();
@@ -242,6 +243,19 @@ namespace DiztinGUIsh.window.dialog
             this.chkIncludeUnusedLabels.UseVisualStyleBackColor = true;
             this.chkIncludeUnusedLabels.CheckedChanged += new System.EventHandler(this.chkIncludeUnusedLabels_CheckedChanged);
             // 
+            // chkOutputExtraWhitespace
+            // 
+            this.chkOutputExtraWhitespace.AutoSize = true;
+            this.chkOutputExtraWhitespace.Checked = true;
+            this.chkOutputExtraWhitespace.Location = new System.Drawing.Point(350, 97);
+            this.chkOutputExtraWhitespace.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkOutputExtraWhitespace.Name = "chkOutputExtraWhitespace";
+            this.chkOutputExtraWhitespace.Size = new System.Drawing.Size(211, 19);
+            this.chkOutputExtraWhitespace.TabIndex = 14;
+            this.chkOutputExtraWhitespace.Text = "Output extra whitespace in assembly code";
+            this.chkOutputExtraWhitespace.UseVisualStyleBackColor = true;
+            this.chkOutputExtraWhitespace.CheckedChanged += new System.EventHandler(this.chkOutputExtraWhitespace_CheckedChanged);
+            // 
             // saveLogSingleFile
             // 
             this.saveLogSingleFile.Filter = "Assembly Files|*.asm|All Files|*.*";
@@ -299,6 +313,7 @@ namespace DiztinGUIsh.window.dialog
             this.Controls.Add(this.txtExportPath);
             this.Controls.Add(this.chkIncludeUnusedLabels);
             this.Controls.Add(this.chkPrintLabelSpecificComments);
+            this.Controls.Add(this.chkOutputExtraWhitespace);
             this.Controls.Add(this.numData);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
@@ -342,6 +357,7 @@ namespace DiztinGUIsh.window.dialog
         private NumericUpDown numData;
         private CheckBox chkPrintLabelSpecificComments;
         private CheckBox chkIncludeUnusedLabels;
+        private CheckBox chkOutputExtraWhitespace;
         private SaveFileDialog saveLogSingleFile;
         private FolderBrowserDialog chooseLogFolder;
         private Label label7;

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
@@ -66,7 +66,7 @@ namespace DiztinGUIsh.window.dialog
             this.cancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cancel.Name = "cancel";
             this.cancel.Size = new System.Drawing.Size(88, 27);
-            this.cancel.TabIndex = 12;
+            this.cancel.TabIndex = 18;
             this.cancel.TabStop = false;
             this.cancel.Text = "Cancel";
             this.cancel.UseVisualStyleBackColor = true;
@@ -78,7 +78,7 @@ namespace DiztinGUIsh.window.dialog
             this.disassembleButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.disassembleButton.Name = "disassembleButton";
             this.disassembleButton.Size = new System.Drawing.Size(132, 27);
-            this.disassembleButton.TabIndex = 11;
+            this.disassembleButton.TabIndex = 19;
             this.disassembleButton.Text = "Start Export!";
             this.disassembleButton.UseVisualStyleBackColor = true;
             this.disassembleButton.Click += new System.EventHandler(this.disassembleButton_Click);
@@ -89,7 +89,7 @@ namespace DiztinGUIsh.window.dialog
             this.textFormat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.textFormat.Name = "textFormat";
             this.textFormat.Size = new System.Drawing.Size(791, 23);
-            this.textFormat.TabIndex = 8;
+            this.textFormat.TabIndex = 15;
             this.textFormat.TextChanged += new System.EventHandler(this.textFormat_TextChanged);
             // 
             // textSample
@@ -102,7 +102,7 @@ namespace DiztinGUIsh.window.dialog
             this.textSample.ReadOnly = true;
             this.textSample.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.textSample.Size = new System.Drawing.Size(881, 358);
-            this.textSample.TabIndex = 10;
+            this.textSample.TabIndex = 17;
             this.textSample.TabStop = false;
             this.textSample.WordWrap = false;
             // 
@@ -140,7 +140,7 @@ namespace DiztinGUIsh.window.dialog
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(87, 15);
-            this.label1.TabIndex = 7;
+            this.label1.TabIndex = 14;
             this.label1.Text = "Output format:";
             // 
             // label2
@@ -150,7 +150,7 @@ namespace DiztinGUIsh.window.dialog
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(90, 15);
-            this.label2.TabIndex = 9;
+            this.label2.TabIndex = 16;
             this.label2.Text = "Sample Output:";
             // 
             // label3
@@ -226,7 +226,7 @@ namespace DiztinGUIsh.window.dialog
             this.chkPrintLabelSpecificComments.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkPrintLabelSpecificComments.Name = "chkPrintLabelSpecificComments";
             this.chkPrintLabelSpecificComments.Size = new System.Drawing.Size(255, 19);
-            this.chkPrintLabelSpecificComments.TabIndex = 13;
+            this.chkPrintLabelSpecificComments.TabIndex = 8;
             this.chkPrintLabelSpecificComments.Text = "Print label-specific comments in labels.asm";
             this.chkPrintLabelSpecificComments.UseVisualStyleBackColor = true;
             this.chkPrintLabelSpecificComments.CheckedChanged += new System.EventHandler(this.chkPrintLabelSpecificComments_CheckedChanged);
@@ -238,7 +238,7 @@ namespace DiztinGUIsh.window.dialog
             this.chkIncludeUnusedLabels.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkIncludeUnusedLabels.Name = "chkIncludeUnusedLabels";
             this.chkIncludeUnusedLabels.Size = new System.Drawing.Size(211, 19);
-            this.chkIncludeUnusedLabels.TabIndex = 14;
+            this.chkIncludeUnusedLabels.TabIndex = 9;
             this.chkIncludeUnusedLabels.Text = "Include unused labels in labels.asm";
             this.chkIncludeUnusedLabels.UseVisualStyleBackColor = true;
             this.chkIncludeUnusedLabels.CheckedChanged += new System.EventHandler(this.chkIncludeUnusedLabels_CheckedChanged);
@@ -251,7 +251,7 @@ namespace DiztinGUIsh.window.dialog
             this.chkOutputExtraWhitespace.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkOutputExtraWhitespace.Name = "chkOutputExtraWhitespace";
             this.chkOutputExtraWhitespace.Size = new System.Drawing.Size(211, 19);
-            this.chkOutputExtraWhitespace.TabIndex = 14;
+            this.chkOutputExtraWhitespace.TabIndex = 7;
             this.chkOutputExtraWhitespace.Text = "Output extra whitespace in assembly code";
             this.chkOutputExtraWhitespace.UseVisualStyleBackColor = true;
             this.chkOutputExtraWhitespace.CheckedChanged += new System.EventHandler(this.chkOutputExtraWhitespace_CheckedChanged);
@@ -267,7 +267,7 @@ namespace DiztinGUIsh.window.dialog
             this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(57, 45);
-            this.label7.TabIndex = 15;
+            this.label7.TabIndex = 10;
             this.label7.Text = "Output \r\ndirectory \r\nor file:";
             // 
             // txtExportPath
@@ -276,7 +276,7 @@ namespace DiztinGUIsh.window.dialog
             this.txtExportPath.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtExportPath.Name = "txtExportPath";
             this.txtExportPath.Size = new System.Drawing.Size(717, 23);
-            this.txtExportPath.TabIndex = 16;
+            this.txtExportPath.TabIndex = 11;
             this.txtExportPath.TextChanged += new System.EventHandler(this.txtExportPath_TextChanged);
             // 
             // btnBrowseOutputPath
@@ -284,7 +284,7 @@ namespace DiztinGUIsh.window.dialog
             this.btnBrowseOutputPath.Location = new System.Drawing.Point(819, 138);
             this.btnBrowseOutputPath.Name = "btnBrowseOutputPath";
             this.btnBrowseOutputPath.Size = new System.Drawing.Size(75, 24);
-            this.btnBrowseOutputPath.TabIndex = 17;
+            this.btnBrowseOutputPath.TabIndex = 12;
             this.btnBrowseOutputPath.Text = "Browse...";
             this.btnBrowseOutputPath.UseVisualStyleBackColor = true;
             this.btnBrowseOutputPath.Click += new System.EventHandler(this.btnBrowseOutputPath_Click);
@@ -296,7 +296,7 @@ namespace DiztinGUIsh.window.dialog
             this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(482, 15);
-            this.label8.TabIndex = 18;
+            this.label8.TabIndex = 13;
             this.label8.Text = "(By default, path is relative to the project file\'s directory. it will be created" +
     " if it doesn\'t exist)";
             // 

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.cs
@@ -55,6 +55,7 @@ public partial class LogCreatorSettingsEditorForm : Form, ILogCreatorSettingsEdi
         comboStructure.SelectedIndex = (int)Settings.Structure;
         chkIncludeUnusedLabels.Checked = Settings.IncludeUnusedLabels;
         chkPrintLabelSpecificComments.Checked = Settings.PrintLabelSpecificComments;
+        chkOutputExtraWhitespace.Checked = Settings.OutputExtraWhitespace;
         txtExportPath.Text = Settings.FileOrFolderOutPath;
         
         var validFormat = LogCreatorLineFormatter.Validate(Settings.Format);
@@ -126,6 +127,9 @@ public partial class LogCreatorSettingsEditorForm : Form, ILogCreatorSettingsEdi
 
     private void chkIncludeUnusedLabels_CheckedChanged(object sender, EventArgs e) => 
         Settings = Settings with {IncludeUnusedLabels = chkIncludeUnusedLabels.Checked};
+
+    private void chkOutputExtraWhitespace_CheckedChanged(object sender, EventArgs e) => 
+        Settings = Settings with {OutputExtraWhitespace = chkOutputExtraWhitespace.Checked};
     
     private void txtExportPath_TextChanged(object sender, EventArgs e) => 
         Settings = Settings with {FileOrFolderOutPath = txtExportPath.Text};


### PR DESCRIPTION
Now, when editing export settings, you can toggle the "OutputExtraWhitespace" setting that previously existed in the code but always defaulted to true.