### PR TITLE
Add additional output settings

### DIFF
--- a/Diz.Core/export/LogWriterSettings.cs
+++ b/Diz.Core/export/LogWriterSettings.cs
@@ -43,6 +43,7 @@ public record LogWriterSettings : ILogWriterSettings
     public bool IncludeUnusedLabels  { get; init; }
     public bool PrintLabelSpecificComments { get; init; }
     public bool OutputExtraWhitespace  { get; init; } = true;
+    public bool GenerateFullLine { get; init; } = true;
         
     /// <summary>
     /// specify an override for the # of bytes to assemble. default is to visit every byte in the entire ROM 

--- a/Diz.Core/export/LogWriterSettings.cs
+++ b/Diz.Core/export/LogWriterSettings.cs
@@ -40,10 +40,11 @@ public record LogWriterSettings : ILogWriterSettings
     public int DataPerLine { get; init; } = 8;
     public FormatUnlabeled Unlabeled { get; init; } = FormatUnlabeled.ShowInPoints;
     public FormatStructure Structure { get; init; } = FormatStructure.OneBankPerFile;
-    public bool IncludeUnusedLabels  { get; init; }
-    public bool PrintLabelSpecificComments { get; init; }
+    public bool NewLine { get; init; } = false;
     public bool OutputExtraWhitespace  { get; init; } = true;
     public bool GenerateFullLine { get; init; } = true;
+    public bool IncludeUnusedLabels  { get; init; }
+    public bool PrintLabelSpecificComments { get; init; }
         
     /// <summary>
     /// specify an override for the # of bytes to assemble. default is to visit every byte in the entire ROM 

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
@@ -218,7 +218,7 @@ namespace DiztinGUIsh.window.dialog
             0,
             0});
             this.numData.ValueChanged += new System.EventHandler(this.numData_ValueChanged);
-                        // 
+            // 
             // chkNewLine
             // 
             this.chkNewLine.AutoSize = true;

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
@@ -50,6 +50,7 @@ namespace DiztinGUIsh.window.dialog
             this.chkPrintLabelSpecificComments = new System.Windows.Forms.CheckBox();
             this.chkIncludeUnusedLabels = new System.Windows.Forms.CheckBox();
             this.chkOutputExtraWhitespace = new System.Windows.Forms.CheckBox();
+            this.chkGenerateFullLine = new System.Windows.Forms.CheckBox();
             this.saveLogSingleFile = new System.Windows.Forms.SaveFileDialog();
             this.chooseLogFolder = new System.Windows.Forms.FolderBrowserDialog();
             this.label7 = new System.Windows.Forms.Label();
@@ -66,7 +67,7 @@ namespace DiztinGUIsh.window.dialog
             this.cancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cancel.Name = "cancel";
             this.cancel.Size = new System.Drawing.Size(88, 27);
-            this.cancel.TabIndex = 18;
+            this.cancel.TabIndex = 19;
             this.cancel.TabStop = false;
             this.cancel.Text = "Cancel";
             this.cancel.UseVisualStyleBackColor = true;
@@ -78,7 +79,7 @@ namespace DiztinGUIsh.window.dialog
             this.disassembleButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.disassembleButton.Name = "disassembleButton";
             this.disassembleButton.Size = new System.Drawing.Size(132, 27);
-            this.disassembleButton.TabIndex = 19;
+            this.disassembleButton.TabIndex = 20;
             this.disassembleButton.Text = "Start Export!";
             this.disassembleButton.UseVisualStyleBackColor = true;
             this.disassembleButton.Click += new System.EventHandler(this.disassembleButton_Click);
@@ -89,7 +90,7 @@ namespace DiztinGUIsh.window.dialog
             this.textFormat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.textFormat.Name = "textFormat";
             this.textFormat.Size = new System.Drawing.Size(791, 23);
-            this.textFormat.TabIndex = 15;
+            this.textFormat.TabIndex = 16;
             this.textFormat.TextChanged += new System.EventHandler(this.textFormat_TextChanged);
             // 
             // textSample
@@ -102,7 +103,7 @@ namespace DiztinGUIsh.window.dialog
             this.textSample.ReadOnly = true;
             this.textSample.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.textSample.Size = new System.Drawing.Size(881, 358);
-            this.textSample.TabIndex = 17;
+            this.textSample.TabIndex = 18;
             this.textSample.TabStop = false;
             this.textSample.WordWrap = false;
             // 
@@ -140,7 +141,7 @@ namespace DiztinGUIsh.window.dialog
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(87, 15);
-            this.label1.TabIndex = 14;
+            this.label1.TabIndex = 15;
             this.label1.Text = "Output format:";
             // 
             // label2
@@ -150,7 +151,7 @@ namespace DiztinGUIsh.window.dialog
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(90, 15);
-            this.label2.TabIndex = 16;
+            this.label2.TabIndex = 17;
             this.label2.Text = "Sample Output:";
             // 
             // label3
@@ -226,7 +227,7 @@ namespace DiztinGUIsh.window.dialog
             this.chkPrintLabelSpecificComments.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkPrintLabelSpecificComments.Name = "chkPrintLabelSpecificComments";
             this.chkPrintLabelSpecificComments.Size = new System.Drawing.Size(255, 19);
-            this.chkPrintLabelSpecificComments.TabIndex = 8;
+            this.chkPrintLabelSpecificComments.TabIndex = 9;
             this.chkPrintLabelSpecificComments.Text = "Print label-specific comments in labels.asm";
             this.chkPrintLabelSpecificComments.UseVisualStyleBackColor = true;
             this.chkPrintLabelSpecificComments.CheckedChanged += new System.EventHandler(this.chkPrintLabelSpecificComments_CheckedChanged);
@@ -234,11 +235,11 @@ namespace DiztinGUIsh.window.dialog
             // chkIncludeUnusedLabels
             // 
             this.chkIncludeUnusedLabels.AutoSize = true;
-            this.chkIncludeUnusedLabels.Location = new System.Drawing.Point(613, 113);
+            this.chkIncludeUnusedLabels.Location = new System.Drawing.Point(613, 114);
             this.chkIncludeUnusedLabels.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkIncludeUnusedLabels.Name = "chkIncludeUnusedLabels";
             this.chkIncludeUnusedLabels.Size = new System.Drawing.Size(211, 19);
-            this.chkIncludeUnusedLabels.TabIndex = 9;
+            this.chkIncludeUnusedLabels.TabIndex = 10;
             this.chkIncludeUnusedLabels.Text = "Include unused labels in labels.asm";
             this.chkIncludeUnusedLabels.UseVisualStyleBackColor = true;
             this.chkIncludeUnusedLabels.CheckedChanged += new System.EventHandler(this.chkIncludeUnusedLabels_CheckedChanged);
@@ -256,6 +257,19 @@ namespace DiztinGUIsh.window.dialog
             this.chkOutputExtraWhitespace.UseVisualStyleBackColor = true;
             this.chkOutputExtraWhitespace.CheckedChanged += new System.EventHandler(this.chkOutputExtraWhitespace_CheckedChanged);
             // 
+            // chkGenerateFullLine
+            // 
+            this.chkGenerateFullLine.AutoSize = true;
+            this.chkGenerateFullLine.Checked = true;
+            this.chkGenerateFullLine.Location = new System.Drawing.Point(350, 114);
+            this.chkGenerateFullLine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkGenerateFullLine.Name = "chkGenerateFullLine";
+            this.chkGenerateFullLine.Size = new System.Drawing.Size(211, 19);
+            this.chkGenerateFullLine.TabIndex = 8;
+            this.chkGenerateFullLine.Text = "Generate full line on special lines";
+            this.chkGenerateFullLine.UseVisualStyleBackColor = true;
+            this.chkGenerateFullLine.CheckedChanged += new System.EventHandler(this.chkGenerateFullLine_CheckedChanged);
+            // 
             // saveLogSingleFile
             // 
             this.saveLogSingleFile.Filter = "Assembly Files|*.asm|All Files|*.*";
@@ -267,7 +281,7 @@ namespace DiztinGUIsh.window.dialog
             this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(57, 45);
-            this.label7.TabIndex = 10;
+            this.label7.TabIndex = 11;
             this.label7.Text = "Output \r\ndirectory \r\nor file:";
             // 
             // txtExportPath
@@ -276,7 +290,7 @@ namespace DiztinGUIsh.window.dialog
             this.txtExportPath.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtExportPath.Name = "txtExportPath";
             this.txtExportPath.Size = new System.Drawing.Size(717, 23);
-            this.txtExportPath.TabIndex = 11;
+            this.txtExportPath.TabIndex = 12;
             this.txtExportPath.TextChanged += new System.EventHandler(this.txtExportPath_TextChanged);
             // 
             // btnBrowseOutputPath
@@ -284,7 +298,7 @@ namespace DiztinGUIsh.window.dialog
             this.btnBrowseOutputPath.Location = new System.Drawing.Point(819, 138);
             this.btnBrowseOutputPath.Name = "btnBrowseOutputPath";
             this.btnBrowseOutputPath.Size = new System.Drawing.Size(75, 24);
-            this.btnBrowseOutputPath.TabIndex = 12;
+            this.btnBrowseOutputPath.TabIndex = 13;
             this.btnBrowseOutputPath.Text = "Browse...";
             this.btnBrowseOutputPath.UseVisualStyleBackColor = true;
             this.btnBrowseOutputPath.Click += new System.EventHandler(this.btnBrowseOutputPath_Click);
@@ -296,7 +310,7 @@ namespace DiztinGUIsh.window.dialog
             this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(482, 15);
-            this.label8.TabIndex = 13;
+            this.label8.TabIndex = 14;
             this.label8.Text = "(By default, path is relative to the project file\'s directory. it will be created" +
     " if it doesn\'t exist)";
             // 
@@ -314,6 +328,7 @@ namespace DiztinGUIsh.window.dialog
             this.Controls.Add(this.chkIncludeUnusedLabels);
             this.Controls.Add(this.chkPrintLabelSpecificComments);
             this.Controls.Add(this.chkOutputExtraWhitespace);
+            this.Controls.Add(this.chkGenerateFullLine);
             this.Controls.Add(this.numData);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
@@ -358,6 +373,7 @@ namespace DiztinGUIsh.window.dialog
         private CheckBox chkPrintLabelSpecificComments;
         private CheckBox chkIncludeUnusedLabels;
         private CheckBox chkOutputExtraWhitespace;
+        private CheckBox chkGenerateFullLine;
         private SaveFileDialog saveLogSingleFile;
         private FolderBrowserDialog chooseLogFolder;
         private Label label7;

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
@@ -47,10 +47,11 @@ namespace DiztinGUIsh.window.dialog
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.numData = new System.Windows.Forms.NumericUpDown();
-            this.chkPrintLabelSpecificComments = new System.Windows.Forms.CheckBox();
-            this.chkIncludeUnusedLabels = new System.Windows.Forms.CheckBox();
+            this.chkNewLine = new System.Windows.Forms.CheckBox();
             this.chkOutputExtraWhitespace = new System.Windows.Forms.CheckBox();
             this.chkGenerateFullLine = new System.Windows.Forms.CheckBox();
+            this.chkPrintLabelSpecificComments = new System.Windows.Forms.CheckBox();
+            this.chkIncludeUnusedLabels = new System.Windows.Forms.CheckBox();            
             this.saveLogSingleFile = new System.Windows.Forms.SaveFileDialog();
             this.chooseLogFolder = new System.Windows.Forms.FolderBrowserDialog();
             this.label7 = new System.Windows.Forms.Label();
@@ -67,7 +68,7 @@ namespace DiztinGUIsh.window.dialog
             this.cancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cancel.Name = "cancel";
             this.cancel.Size = new System.Drawing.Size(88, 27);
-            this.cancel.TabIndex = 19;
+            this.cancel.TabIndex = 20;
             this.cancel.TabStop = false;
             this.cancel.Text = "Cancel";
             this.cancel.UseVisualStyleBackColor = true;
@@ -79,7 +80,7 @@ namespace DiztinGUIsh.window.dialog
             this.disassembleButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.disassembleButton.Name = "disassembleButton";
             this.disassembleButton.Size = new System.Drawing.Size(132, 27);
-            this.disassembleButton.TabIndex = 20;
+            this.disassembleButton.TabIndex = 21;
             this.disassembleButton.Text = "Start Export!";
             this.disassembleButton.UseVisualStyleBackColor = true;
             this.disassembleButton.Click += new System.EventHandler(this.disassembleButton_Click);
@@ -90,7 +91,7 @@ namespace DiztinGUIsh.window.dialog
             this.textFormat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.textFormat.Name = "textFormat";
             this.textFormat.Size = new System.Drawing.Size(791, 23);
-            this.textFormat.TabIndex = 16;
+            this.textFormat.TabIndex = 17;
             this.textFormat.TextChanged += new System.EventHandler(this.textFormat_TextChanged);
             // 
             // textSample
@@ -103,7 +104,7 @@ namespace DiztinGUIsh.window.dialog
             this.textSample.ReadOnly = true;
             this.textSample.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.textSample.Size = new System.Drawing.Size(881, 358);
-            this.textSample.TabIndex = 18;
+            this.textSample.TabIndex = 19;
             this.textSample.TabStop = false;
             this.textSample.WordWrap = false;
             // 
@@ -141,7 +142,7 @@ namespace DiztinGUIsh.window.dialog
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(87, 15);
-            this.label1.TabIndex = 15;
+            this.label1.TabIndex = 16;
             this.label1.Text = "Output format:";
             // 
             // label2
@@ -151,7 +152,7 @@ namespace DiztinGUIsh.window.dialog
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(90, 15);
-            this.label2.TabIndex = 17;
+            this.label2.TabIndex = 18;
             this.label2.Text = "Sample Output:";
             // 
             // label3
@@ -217,6 +218,45 @@ namespace DiztinGUIsh.window.dialog
             0,
             0});
             this.numData.ValueChanged += new System.EventHandler(this.numData_ValueChanged);
+                        // 
+            // chkNewLine
+            // 
+            this.chkNewLine.AutoSize = true;
+            this.chkNewLine.Checked = false;
+            this.chkNewLine.Location = new System.Drawing.Point(103, 97);
+            this.chkNewLine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkNewLine.Name = "chkNewLine";
+            this.chkNewLine.Size = new System.Drawing.Size(211, 19);
+            this.chkNewLine.TabIndex = 7;
+            this.chkNewLine.Text = "Print labels on their own lines";
+            this.chkNewLine.UseVisualStyleBackColor = true;
+            this.chkNewLine.CheckedChanged += new System.EventHandler(this.chkNewLine_CheckedChanged);
+            // 
+            // chkOutputExtraWhitespace
+            // 
+            this.chkOutputExtraWhitespace.AutoSize = true;
+            this.chkOutputExtraWhitespace.Checked = true;
+            this.chkOutputExtraWhitespace.Location = new System.Drawing.Point(359, 97);
+            this.chkOutputExtraWhitespace.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkOutputExtraWhitespace.Name = "chkOutputExtraWhitespace";
+            this.chkOutputExtraWhitespace.Size = new System.Drawing.Size(211, 19);
+            this.chkOutputExtraWhitespace.TabIndex = 8;
+            this.chkOutputExtraWhitespace.Text = "Output extra whitespace in assembly code";
+            this.chkOutputExtraWhitespace.UseVisualStyleBackColor = true;
+            this.chkOutputExtraWhitespace.CheckedChanged += new System.EventHandler(this.chkOutputExtraWhitespace_CheckedChanged);
+            // 
+            // chkGenerateFullLine
+            // 
+            this.chkGenerateFullLine.AutoSize = true;
+            this.chkGenerateFullLine.Checked = true;
+            this.chkGenerateFullLine.Location = new System.Drawing.Point(359, 114);
+            this.chkGenerateFullLine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.chkGenerateFullLine.Name = "chkGenerateFullLine";
+            this.chkGenerateFullLine.Size = new System.Drawing.Size(211, 19);
+            this.chkGenerateFullLine.TabIndex = 9;
+            this.chkGenerateFullLine.Text = "Generate full line on special lines";
+            this.chkGenerateFullLine.UseVisualStyleBackColor = true;
+            this.chkGenerateFullLine.CheckedChanged += new System.EventHandler(this.chkGenerateFullLine_CheckedChanged);
             // 
             // chkPrintLabelSpecificComments
             // 
@@ -227,7 +267,7 @@ namespace DiztinGUIsh.window.dialog
             this.chkPrintLabelSpecificComments.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkPrintLabelSpecificComments.Name = "chkPrintLabelSpecificComments";
             this.chkPrintLabelSpecificComments.Size = new System.Drawing.Size(255, 19);
-            this.chkPrintLabelSpecificComments.TabIndex = 9;
+            this.chkPrintLabelSpecificComments.TabIndex = 10;
             this.chkPrintLabelSpecificComments.Text = "Print label-specific comments in labels.asm";
             this.chkPrintLabelSpecificComments.UseVisualStyleBackColor = true;
             this.chkPrintLabelSpecificComments.CheckedChanged += new System.EventHandler(this.chkPrintLabelSpecificComments_CheckedChanged);
@@ -239,36 +279,10 @@ namespace DiztinGUIsh.window.dialog
             this.chkIncludeUnusedLabels.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.chkIncludeUnusedLabels.Name = "chkIncludeUnusedLabels";
             this.chkIncludeUnusedLabels.Size = new System.Drawing.Size(211, 19);
-            this.chkIncludeUnusedLabels.TabIndex = 10;
+            this.chkIncludeUnusedLabels.TabIndex = 11;
             this.chkIncludeUnusedLabels.Text = "Include unused labels in labels.asm";
             this.chkIncludeUnusedLabels.UseVisualStyleBackColor = true;
             this.chkIncludeUnusedLabels.CheckedChanged += new System.EventHandler(this.chkIncludeUnusedLabels_CheckedChanged);
-            // 
-            // chkOutputExtraWhitespace
-            // 
-            this.chkOutputExtraWhitespace.AutoSize = true;
-            this.chkOutputExtraWhitespace.Checked = true;
-            this.chkOutputExtraWhitespace.Location = new System.Drawing.Point(350, 97);
-            this.chkOutputExtraWhitespace.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.chkOutputExtraWhitespace.Name = "chkOutputExtraWhitespace";
-            this.chkOutputExtraWhitespace.Size = new System.Drawing.Size(211, 19);
-            this.chkOutputExtraWhitespace.TabIndex = 7;
-            this.chkOutputExtraWhitespace.Text = "Output extra whitespace in assembly code";
-            this.chkOutputExtraWhitespace.UseVisualStyleBackColor = true;
-            this.chkOutputExtraWhitespace.CheckedChanged += new System.EventHandler(this.chkOutputExtraWhitespace_CheckedChanged);
-            // 
-            // chkGenerateFullLine
-            // 
-            this.chkGenerateFullLine.AutoSize = true;
-            this.chkGenerateFullLine.Checked = true;
-            this.chkGenerateFullLine.Location = new System.Drawing.Point(350, 114);
-            this.chkGenerateFullLine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.chkGenerateFullLine.Name = "chkGenerateFullLine";
-            this.chkGenerateFullLine.Size = new System.Drawing.Size(211, 19);
-            this.chkGenerateFullLine.TabIndex = 8;
-            this.chkGenerateFullLine.Text = "Generate full line on special lines";
-            this.chkGenerateFullLine.UseVisualStyleBackColor = true;
-            this.chkGenerateFullLine.CheckedChanged += new System.EventHandler(this.chkGenerateFullLine_CheckedChanged);
             // 
             // saveLogSingleFile
             // 
@@ -281,7 +295,7 @@ namespace DiztinGUIsh.window.dialog
             this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(57, 45);
-            this.label7.TabIndex = 11;
+            this.label7.TabIndex = 12;
             this.label7.Text = "Output \r\ndirectory \r\nor file:";
             // 
             // txtExportPath
@@ -290,7 +304,7 @@ namespace DiztinGUIsh.window.dialog
             this.txtExportPath.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtExportPath.Name = "txtExportPath";
             this.txtExportPath.Size = new System.Drawing.Size(717, 23);
-            this.txtExportPath.TabIndex = 12;
+            this.txtExportPath.TabIndex = 13;
             this.txtExportPath.TextChanged += new System.EventHandler(this.txtExportPath_TextChanged);
             // 
             // btnBrowseOutputPath
@@ -298,7 +312,7 @@ namespace DiztinGUIsh.window.dialog
             this.btnBrowseOutputPath.Location = new System.Drawing.Point(819, 138);
             this.btnBrowseOutputPath.Name = "btnBrowseOutputPath";
             this.btnBrowseOutputPath.Size = new System.Drawing.Size(75, 24);
-            this.btnBrowseOutputPath.TabIndex = 13;
+            this.btnBrowseOutputPath.TabIndex = 14;
             this.btnBrowseOutputPath.Text = "Browse...";
             this.btnBrowseOutputPath.UseVisualStyleBackColor = true;
             this.btnBrowseOutputPath.Click += new System.EventHandler(this.btnBrowseOutputPath_Click);
@@ -310,7 +324,7 @@ namespace DiztinGUIsh.window.dialog
             this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(482, 15);
-            this.label8.TabIndex = 14;
+            this.label8.TabIndex = 15;
             this.label8.Text = "(By default, path is relative to the project file\'s directory. it will be created" +
     " if it doesn\'t exist)";
             // 
@@ -325,10 +339,11 @@ namespace DiztinGUIsh.window.dialog
             this.Controls.Add(this.btnBrowseOutputPath);
             this.Controls.Add(this.label7);
             this.Controls.Add(this.txtExportPath);
-            this.Controls.Add(this.chkIncludeUnusedLabels);
-            this.Controls.Add(this.chkPrintLabelSpecificComments);
+            this.Controls.Add(this.chkNewLine);
             this.Controls.Add(this.chkOutputExtraWhitespace);
             this.Controls.Add(this.chkGenerateFullLine);
+            this.Controls.Add(this.chkIncludeUnusedLabels);
+            this.Controls.Add(this.chkPrintLabelSpecificComments);
             this.Controls.Add(this.numData);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
@@ -370,10 +385,11 @@ namespace DiztinGUIsh.window.dialog
         private Label label5;
         private Label label6;
         private NumericUpDown numData;
-        private CheckBox chkPrintLabelSpecificComments;
-        private CheckBox chkIncludeUnusedLabels;
+        private CheckBox chkNewLine;
         private CheckBox chkOutputExtraWhitespace;
         private CheckBox chkGenerateFullLine;
+        private CheckBox chkPrintLabelSpecificComments;
+        private CheckBox chkIncludeUnusedLabels;
         private SaveFileDialog saveLogSingleFile;
         private FolderBrowserDialog chooseLogFolder;
         private Label label7;

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.cs
@@ -56,6 +56,7 @@ public partial class LogCreatorSettingsEditorForm : Form, ILogCreatorSettingsEdi
         chkIncludeUnusedLabels.Checked = Settings.IncludeUnusedLabels;
         chkPrintLabelSpecificComments.Checked = Settings.PrintLabelSpecificComments;
         chkOutputExtraWhitespace.Checked = Settings.OutputExtraWhitespace;
+        chkGenerateFullLine.Checked = Settings.GenerateFullLine;
         txtExportPath.Text = Settings.FileOrFolderOutPath;
         
         var validFormat = LogCreatorLineFormatter.Validate(Settings.Format);
@@ -130,6 +131,9 @@ public partial class LogCreatorSettingsEditorForm : Form, ILogCreatorSettingsEdi
 
     private void chkOutputExtraWhitespace_CheckedChanged(object sender, EventArgs e) => 
         Settings = Settings with {OutputExtraWhitespace = chkOutputExtraWhitespace.Checked};
+
+    private void chkGenerateFullLine_CheckedChanged(object sender, EventArgs e) =>
+        Settings = Settings with {GenerateFullLine = chkGenerateFullLine.Checked};
     
     private void txtExportPath_TextChanged(object sender, EventArgs e) => 
         Settings = Settings with {FileOrFolderOutPath = txtExportPath.Text};

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.cs
@@ -53,10 +53,11 @@ public partial class LogCreatorSettingsEditorForm : Form, ILogCreatorSettingsEdi
         numData.Value = Settings.DataPerLine;
         comboUnlabeled.SelectedIndex = (int)Settings.Unlabeled;
         comboStructure.SelectedIndex = (int)Settings.Structure;
-        chkIncludeUnusedLabels.Checked = Settings.IncludeUnusedLabels;
-        chkPrintLabelSpecificComments.Checked = Settings.PrintLabelSpecificComments;
+        chkNewLine.Checked = Settings.NewLine;
         chkOutputExtraWhitespace.Checked = Settings.OutputExtraWhitespace;
         chkGenerateFullLine.Checked = Settings.GenerateFullLine;
+        chkIncludeUnusedLabels.Checked = Settings.IncludeUnusedLabels;
+        chkPrintLabelSpecificComments.Checked = Settings.PrintLabelSpecificComments;
         txtExportPath.Text = Settings.FileOrFolderOutPath;
         
         var validFormat = LogCreatorLineFormatter.Validate(Settings.Format);
@@ -122,18 +123,21 @@ public partial class LogCreatorSettingsEditorForm : Form, ILogCreatorSettingsEdi
 
     private void comboStructure_SelectedIndexChanged(object sender, EventArgs e) =>
         Settings = Settings with {Structure = StructureFormat};
-        
-    private void chkPrintLabelSpecificComments_CheckedChanged(object sender, EventArgs e) => 
-        Settings = Settings with {PrintLabelSpecificComments = chkPrintLabelSpecificComments.Checked};
 
-    private void chkIncludeUnusedLabels_CheckedChanged(object sender, EventArgs e) => 
-        Settings = Settings with {IncludeUnusedLabels = chkIncludeUnusedLabels.Checked};
+    private void chkNewLine_CheckedChanged(object sender, EventArgs e) =>
+        Settings = Settings with {NewLine = chkNewLine.Checked};
 
     private void chkOutputExtraWhitespace_CheckedChanged(object sender, EventArgs e) => 
         Settings = Settings with {OutputExtraWhitespace = chkOutputExtraWhitespace.Checked};
 
     private void chkGenerateFullLine_CheckedChanged(object sender, EventArgs e) =>
         Settings = Settings with {GenerateFullLine = chkGenerateFullLine.Checked};
+        
+    private void chkPrintLabelSpecificComments_CheckedChanged(object sender, EventArgs e) => 
+        Settings = Settings with {PrintLabelSpecificComments = chkPrintLabelSpecificComments.Checked};
+
+    private void chkIncludeUnusedLabels_CheckedChanged(object sender, EventArgs e) => 
+        Settings = Settings with {IncludeUnusedLabels = chkIncludeUnusedLabels.Checked};
     
     private void txtExportPath_TextChanged(object sender, EventArgs e) => 
         Settings = Settings with {FileOrFolderOutPath = txtExportPath.Text};


### PR DESCRIPTION
This PR adds a checkbox in the export settings that toggles if a line should output anything after the %code% column on special lines and whether to print labels on their own lines.

Currently, special lines add unnecessary characters such as empty spaces for %pc%, %bytes%, %ia%, as well as any literals included in the output format, resulting in generated code that looks like:
```
                       lorom                                ; [      |        |      ]  
                                                            ; [      |        |      ]  
                                                            ; [      |        |      ]  
                       ORG $808000                          ; [      |        |      ]  
                                                            ; [      |        |      ]  
                                                            ; [      |        |      ]  
      Emulation_RESET: SEI                                  ; [808000|78      |      ] Sample emulation reset location
                       LDA.B #$01                           ; [808001|A901    |      ]  
                       STA.W $420D                          ; [808003|8D0D42  |00420D] this sets FastROM
                       JML.L FastRESET                      ; [808006|5C0A8080|80800A]  
```
When the added checkbox is unchecked, the generated code does not include anything after the %code% column, resulting in cleaner looking code:
```
                       lorom                                
                                                            
                                                            
                       ORG $808000                          
                                                            
                                                            
      Emulation_RESET: SEI                                  ; [808000|78      |      ] Sample emulation reset location
                       LDA.B #$01                           ; [808001|A901    |      ]  
                       STA.W $420D                          ; [808003|8D0D42  |00420D] this sets FastROM
                       JML.L FastRESET                      ; [808006|5C0A8080|80800A]  
```
Additionally, this PR allows you to output labels on their own lines:
```
    lorom
 
 
    ORG $808000
 
 
Emulation_RESET:
    SEI                                  ; [808000|78      |      ] Sample emulation reset location
    LDA.B #$01                           ; [808001|A901    |      ]
    STA.W $420D                          ; [808003|8D0D42  |00420D] this sets FastROM
    JML.L FastRESET                      ; [808006|5C0A8080|80800A]
```

This PR requires [PR #2](https://github.com/DizTools/Diz.LogWriter/pull/2) of Diz.LogWriter.

This PR fixes issue #93.