### PR TITLE
Replace error window on first export

### DIFF
--- a/Diz.Controllers/Diz.Controllers/src/controllers/ProjectController.cs
+++ b/Diz.Controllers/Diz.Controllers/src/controllers/ProjectController.cs
@@ -346,10 +346,7 @@ public class ProjectController : IProjectController
         if (WriteAssemblyOutputIfSettingsValid())
             return true;
 
-        var errMsg = "Can't export assembly because the project export settings are invalid.\nPlease edit your export settings first. Errors were:";
-
-        errMsg += $"\n{Project.LogWriterSettings.Validate(fs)}";
-        commonGui.ShowError(errMsg);
+        ConfirmSettingsThenExportAssembly();
         return false;
     }
 

--- a/Diz.Controllers/Diz.Controllers/src/controllers/ProjectController.cs
+++ b/Diz.Controllers/Diz.Controllers/src/controllers/ProjectController.cs
@@ -346,8 +346,7 @@ public class ProjectController : IProjectController
         if (WriteAssemblyOutputIfSettingsValid())
             return true;
 
-        ConfirmSettingsThenExportAssembly();
-        return false;
+        return ConfirmSettingsThenExportAssembly();
     }
 
     public LogWriterSettings? ShowSettingsEditorUntilValid()


### PR DESCRIPTION
This PR streamlines the process of the first export of a project. Rather than prompting the user to open the export settings via an error window, Diz will now do so automatically.