### PR TITLE
Add menu button/keyboard shortcut to open export directory

### DIFF
--- a/DiztinGUIsh/window/MainWindow.Actions.cs
+++ b/DiztinGUIsh/window/MainWindow.Actions.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Forms;
+﻿using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
 using Diz.Controllers.controllers;
 using Diz.Controllers.interfaces;
 using Diz.Core.commands;
@@ -43,6 +45,31 @@ public partial class MainWindow
             return;
 
         ProjectController.ImportRomAndCreateNewProject(openFileDialog.FileName);
+    }
+
+    private void OpenExportDirectory()
+    {
+        var projectSettings = ProjectController.Project.LogWriterSettings;
+        var exportDirectory = Path.Combine(projectSettings.BaseOutputPath, projectSettings.FileOrFolderOutPath);
+
+        OpenDirectory(exportDirectory);
+    }
+
+    private void OpenDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                Arguments = path,
+                FileName = "explorer.exe",
+            };
+            Process.Start(startInfo);
+        }
+        else
+        {
+            MessageBox.Show(string.Format("{0} does not exist!", path));
+        }
     }
 
     private void Step(int offset)

--- a/DiztinGUIsh/window/MainWindow.Designer.cs
+++ b/DiztinGUIsh/window/MainWindow.Designer.cs
@@ -75,6 +75,8 @@
             this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStrip_exportDisassemblyUseCurrentSettings = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStrip_exportDisassemblyEditSettingsFirst = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStrip_openExportDirectory = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -500,7 +502,9 @@
             // 
             this.exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStrip_exportDisassemblyUseCurrentSettings,
-            this.toolStrip_exportDisassemblyEditSettingsFirst});
+            this.toolStrip_exportDisassemblyEditSettingsFirst,
+            this.toolStripSeparator11,
+            this.toolStrip_openExportDirectory});
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
             this.exportToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
             this.exportToolStripMenuItem.Text = "Export";
@@ -522,6 +526,20 @@
             this.toolStrip_exportDisassemblyEditSettingsFirst.Size = new System.Drawing.Size(334, 22);
             this.toolStrip_exportDisassemblyEditSettingsFirst.Text = "Export Disassemly (Edit Settings First)";
             this.toolStrip_exportDisassemblyEditSettingsFirst.Click += new System.EventHandler(this.toolStrip_exportDisassemblyEditSettingsFirst_Click);
+            // 
+            // toolStripSeparator11
+            // 
+            this.toolStripSeparator11.Name = "toolStripSeparator11";
+            this.toolStripSeparator11.Size = new System.Drawing.Size(215, 6);
+            // 
+            // toolStrip_openExportDirectory
+            // 
+            this.toolStrip_openExportDirectory.Enabled = false;
+            this.toolStrip_openExportDirectory.Name = "toolStrip_openExportDirectory";
+            this.toolStrip_openExportDirectory.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.O)));
+            this.toolStrip_openExportDirectory.Size = new System.Drawing.Size(334, 22);
+            this.toolStrip_openExportDirectory.Text = "Open Export Directory";
+            this.toolStrip_openExportDirectory.Click += new System.EventHandler(this.toolStrip_openExportDirectory_Click);
             // 
             // toolStripSeparator7
             // 
@@ -1289,6 +1307,8 @@
         private System.Windows.Forms.ToolStripMenuItem exportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toolStrip_exportDisassemblyUseCurrentSettings;
         private System.Windows.Forms.ToolStripMenuItem toolStrip_exportDisassemblyEditSettingsFirst;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
+        private System.Windows.Forms.ToolStripMenuItem toolStrip_openExportDirectory;
     }
 }
 

--- a/DiztinGUIsh/window/MainWindow.SimpleUI.cs
+++ b/DiztinGUIsh/window/MainWindow.SimpleUI.cs
@@ -31,6 +31,9 @@ namespace DiztinGUIsh.window
         private void toolStrip_exportDisassemblyEditSettingsFirst_Click(object sender, EventArgs e) =>
             ProjectController?.ConfirmSettingsThenExportAssembly();
 
+        private void toolStrip_openExportDirectory_Click(object sender, EventArgs e) =>
+            OpenExportDirectory();
+
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e) =>
             ProjectController.ViewFactory.GetAboutView().Show();
         

--- a/DiztinGUIsh/window/MainWindow.StateUpdate.cs
+++ b/DiztinGUIsh/window/MainWindow.StateUpdate.cs
@@ -156,6 +156,7 @@ namespace DiztinGUIsh.window
 
             toolStrip_exportDisassemblyUseCurrentSettings.Enabled = true;
             toolStrip_exportDisassemblyEditSettingsFirst.Enabled = true;
+            toolStrip_openExportDirectory.Enabled = true;
         }
 
         private void UpdateSomeUI2()


### PR DESCRIPTION
Adds a button in the export menu to open the export directory via Windows Explorer; this also can be opened via the keyboard shortcut Ctrl+Shift+O.

Unfortunately, this is not a platform-independent solution, so this will have to be reworked when/if a more cross-platform/platform-independent UI is released.